### PR TITLE
Moving ts-essentials to global dependencies

### DIFF
--- a/apps/explorer/package.json
+++ b/apps/explorer/package.json
@@ -40,7 +40,6 @@
     "postcss": "^8.4.47",
     "postcss-preset-mantine": "^1.17.0",
     "postcss-simple-vars": "^7.0.1",
-    "ts-essentials": "^10.0.2",
     "typescript": "^5.6.2",
     "vite": "^5.4.6"
   }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "turbo": "^2.1.2",
     "typedoc": "^0.26.7",
     "typedoc-plugin-markdown": "^4.2.7",
+    "ts-essentials": "^10.0.2",
     "typescript": "^5.6.2"
   },
   "pnpm": {

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -45,8 +45,7 @@
   },
   "devDependencies": {
     "@didtools/key-did": "^1.0.0",
-    "dids": "^5.0.2",
-    "ts-essentials": "^10.0.2"
+    "dids": "^5.0.2"
   },
   "jest": {
     "extensionsToTreatAsEsm": [".ts"],

--- a/packages/model-instance-handler/package.json
+++ b/packages/model-instance-handler/package.json
@@ -47,8 +47,7 @@
     "@ceramic-sdk/model-protocol": "workspace:^",
     "@didtools/key-did": "^1.0.0",
     "dids": "^5.0.2",
-    "multiformats": "^13.3.0",
-    "ts-essentials": "^10.0.2"
+    "multiformats": "^13.3.0"
   },
   "jest": {
     "extensionsToTreatAsEsm": [".ts"],

--- a/packages/model-instance-protocol/package.json
+++ b/packages/model-instance-protocol/package.json
@@ -39,8 +39,7 @@
     "object-sizeof": "^2.6.4"
   },
   "devDependencies": {
-    "multiformats": "^13.3.0",
-    "ts-essentials": "^10.0.2"
+    "multiformats": "^13.3.0"
   },
   "jest": {
     "extensionsToTreatAsEsm": [".ts"],

--- a/packages/model-protocol/package.json
+++ b/packages/model-protocol/package.json
@@ -44,8 +44,7 @@
   "devDependencies": {
     "@ceramic-sdk/test-utils": "workspace:^",
     "json-schema-typed": "^8.0.1",
-    "multiformats": "^13.3.0",
-    "ts-essentials": "^10.0.2"
+    "multiformats": "^13.3.0"
   },
   "jest": {
     "extensionsToTreatAsEsm": [".ts"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 0.2.2
       '@swc/cli':
         specifier: ^0.4.0
-        version: 0.4.0(@swc/core@1.7.26)(chokidar@4.0.0)
+        version: 0.4.0(@swc/core@1.7.26)(chokidar@3.6.0)
       '@swc/core':
         specifier: ^1.7.24
         version: 1.7.26
@@ -38,6 +38,9 @@ importers:
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@22.5.5)
+      ts-essentials:
+        specifier: ^10.0.2
+        version: 10.0.2(typescript@5.6.2)
       tsx:
         specifier: ^4.19.0
         version: 4.19.0
@@ -135,9 +138,6 @@ importers:
       postcss-simple-vars:
         specifier: ^7.0.1
         version: 7.0.1(postcss@8.4.47)
-      ts-essentials:
-        specifier: ^10.0.2
-        version: 10.0.2(typescript@5.6.2)
       typescript:
         specifier: ^5.6.2
         version: 5.6.2
@@ -184,9 +184,6 @@ importers:
       dids:
         specifier: ^5.0.2
         version: 5.0.2(typescript@5.6.2)(zod@3.23.8)
-      ts-essentials:
-        specifier: ^10.0.2
-        version: 10.0.2(typescript@5.6.2)
 
   packages/http-client:
     dependencies:
@@ -383,9 +380,6 @@ importers:
       multiformats:
         specifier: ^13.3.0
         version: 13.3.0
-      ts-essentials:
-        specifier: ^10.0.2
-        version: 10.0.2(typescript@5.6.2)
 
   packages/model-instance-protocol:
     dependencies:
@@ -408,9 +402,6 @@ importers:
       multiformats:
         specifier: ^13.3.0
         version: 13.3.0
-      ts-essentials:
-        specifier: ^10.0.2
-        version: 10.0.2(typescript@5.6.2)
 
   packages/model-protocol:
     dependencies:
@@ -448,9 +439,6 @@ importers:
       multiformats:
         specifier: ^13.3.0
         version: 13.3.0
-      ts-essentials:
-        specifier: ^10.0.2
-        version: 10.0.2(typescript@5.6.2)
 
   packages/test-utils:
     dependencies:
@@ -2064,10 +2052,6 @@ packages:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
 
-  chokidar@4.0.0:
-    resolution: {integrity: sha512-mxIojEAQcuEvT/lyXq+jf/3cO/KoA6z4CeNDGGevTybECPOMFCnQy3OPahluUkbqgPNGw5Bi78UC7Po6Lhy+NA==}
-    engines: {node: '>= 14.16.0'}
-
   ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
     engines: {node: '>=8'}
@@ -3345,10 +3329,6 @@ packages:
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
-
-  readdirp@4.0.1:
-    resolution: {integrity: sha512-GkMg9uOTpIWWKbSsgwb5fA4EavTR+SG/PMPoAY8hkhHfEEY0/vqljY+XHqtDf2cr2IJtoNRDbrrEpZUiZCkYRw==}
-    engines: {node: '>= 14.16.0'}
 
   redent@4.0.0:
     resolution: {integrity: sha512-tYkDkVVtYkSVhuQ4zBgfvciymHaeuel+zFKXShfDnFP5SyVEP7qo70Rf1jTOTCx3vGNAbnEi/xFkcfQVMIBWag==}
@@ -5067,7 +5047,7 @@ snapshots:
 
   '@stablelib/wipe@1.0.1': {}
 
-  '@swc/cli@0.4.0(@swc/core@1.7.26)(chokidar@4.0.0)':
+  '@swc/cli@0.4.0(@swc/core@1.7.26)(chokidar@3.6.0)':
     dependencies:
       '@mole-inc/bin-wrapper': 8.0.1
       '@swc/core': 1.7.26
@@ -5080,7 +5060,7 @@ snapshots:
       slash: 3.0.0
       source-map: 0.7.4
     optionalDependencies:
-      chokidar: 4.0.0
+      chokidar: 3.6.0
 
   '@swc/core-darwin-arm64@1.7.26':
     optional: true
@@ -5606,11 +5586,6 @@ snapshots:
       readdirp: 3.6.0
     optionalDependencies:
       fsevents: 2.3.3
-
-  chokidar@4.0.0:
-    dependencies:
-      readdirp: 4.0.1
-    optional: true
 
   ci-info@3.9.0: {}
 
@@ -7098,9 +7073,6 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
-
-  readdirp@4.0.1:
-    optional: true
 
   redent@4.0.0:
     dependencies:


### PR DESCRIPTION
- ts-essentials package needed for http-client (and other packages) to run, but had not previously been listed as package dependency in http-client package
- Moved to the SDK's global dependencies list (version matching based on usage across 4 other packages)
- Removed as local package dependencies from events, model-instance-handler, model-instance-protocol, and model-protocol