### PR TITLE
chore: flight sql cleanup

### DIFF
--- a/packages/flight-sql-client/src/error.rs
+++ b/packages/flight-sql-client/src/error.rs
@@ -8,17 +8,17 @@ pub type Result<T, E = Error> = std::result::Result<T, E>;
 #[derive(Debug, Snafu)]
 #[snafu(visibility(pub(crate)))]
 pub enum Error {
-    #[snafu(display("column '{name}' is missing"))]
-    MissingColumn { name: String },
-    #[snafu(display("{message}"))]
+    #[snafu(display("{message}: {source:?}"))]
     Arrow {
         source: ArrowError,
         message: &'static str,
     },
+    #[snafu(display("{message}: {source:?}"))]
     Flight {
         source: FlightError,
         message: &'static str,
     },
+    #[snafu(display("{message}: {source}"))]
     Status {
         source: Status,
         message: &'static str,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -585,8 +585,8 @@ importers:
         specifier: 18.0.0
         version: 18.0.0
       cross-spawn:
-        specifier: ^7.0.5
-        version: 7.0.5
+        specifier: ^7.0.6
+        version: 7.0.6
       modern-spawn:
         specifier: ^1.0.0
         version: 1.0.0
@@ -2269,8 +2269,8 @@ packages:
   cross-spawn@5.1.0:
     resolution: {integrity: sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==}
 
-  cross-spawn@7.0.5:
-    resolution: {integrity: sha512-ZVJrKKYunU38/76t0RMOulHOnUcbU9GbpWKAOZ0mhjr7CX6FVrH+4FrAapSOekrgFQ3f/8gwMEuIft0aKq6Hug==}
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
   cssesc@3.0.0:
@@ -5955,7 +5955,7 @@ snapshots:
       shebang-command: 1.2.0
       which: 1.3.1
 
-  cross-spawn@7.0.5:
+  cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
@@ -6177,7 +6177,7 @@ snapshots:
 
   execa@5.1.1:
     dependencies:
-      cross-spawn: 7.0.5
+      cross-spawn: 7.0.6
       get-stream: 6.0.1
       human-signals: 2.1.0
       is-stream: 2.0.1
@@ -7035,7 +7035,7 @@ snapshots:
 
   modern-spawn@1.0.0:
     dependencies:
-      cross-spawn: 7.0.5
+      cross-spawn: 7.0.6
 
   ms@2.1.2: {}
 

--- a/tests/c1-integration/package.json
+++ b/tests/c1-integration/package.json
@@ -34,7 +34,7 @@
     "apache-arrow": "18.0.0",
     "@jest/environment": "^29.7.0",
     "@types/cross-spawn": "^6.0.0",
-    "cross-spawn": "^7.0.5",
+    "cross-spawn": "^7.0.6",
     "modern-spawn": "^1.0.0"
   },
   "devDependencies": {},

--- a/tests/c1-integration/test/flight.test.ts
+++ b/tests/c1-integration/test/flight.test.ts
@@ -37,7 +37,7 @@ describe('flight sql', () => {
 
   test('makes query', async () => {
     const client = await getClient()
-    const buffer = await client.query('SELECT * FROM conclusion_feed')
+    const buffer = await client.query('SELECT * FROM conclusion_events')
     const data = tableFromIPC(buffer)
     console.log(JSON.stringify(data))
   })

--- a/tests/c1-integration/test/flight.test.ts
+++ b/tests/c1-integration/test/flight.test.ts
@@ -68,11 +68,12 @@ describe('flight sql', () => {
   // disabled until server support is implemented
   test.skip('prepared stmt', async () => {
     const client = await createFlightSqlClient(OPTIONS)
-    const data = await client.preparedStatement(
-      'SELECT * from conclusion_feed where stream_type = $1',
+    const buffer = await client.preparedStatement(
+      'SELECT * from conclusion_events where stream_type = $1',
       new Array(['$1', '3']),
     )
-    console.log(data)
+    const data = tableFromIPC(buffer)
+    console.log(JSON.stringify(data))
   })
 
   afterAll(async () => {


### PR DESCRIPTION
Some minor changes to include more error context, update a dependency to a version without a security vulnerability and modify the test so it will pass when unskipped (after the ceramic-one [release with support](https://github.com/ceramicnetwork/rust-ceramic/pull/600)).