### PR TITLE
Consistent naming of ModelInstanceClient class

### DIFF
--- a/docs/@ceramic-sdk/model-instance-client/README.md
+++ b/docs/@ceramic-sdk/model-instance-client/README.md
@@ -8,7 +8,7 @@
 
 ## Classes
 
-- [DocumentClient](classes/DocumentClient.md)
+- [ModelInstanceClient](classes/ModelInstanceClient.md)
 
 ## Type Aliases
 

--- a/docs/@ceramic-sdk/model-instance-client/classes/ModelInstanceClient.md
+++ b/docs/@ceramic-sdk/model-instance-client/classes/ModelInstanceClient.md
@@ -2,9 +2,9 @@
 
 ***
 
-[Ceramic SDK](../../../README.md) / [@ceramic-sdk/model-instance-client](../README.md) / DocumentClient
+[Ceramic SDK](../../../README.md) / [@ceramic-sdk/model-instance-client](../README.md) / ModelInstanceClient
 
-# Class: DocumentClient
+# Class: ModelInstanceClient
 
 ## Extends
 
@@ -12,9 +12,9 @@
 
 ## Constructors
 
-### new DocumentClient()
+### new ModelInstanceClient()
 
-> **new DocumentClient**(`params`): [`DocumentClient`](DocumentClient.md)
+> **new ModelInstanceClient**(`params`): [`ModelInstanceClient`](ModelInstanceClient.md)
 
 #### Parameters
 
@@ -22,7 +22,7 @@
 
 #### Returns
 
-[`DocumentClient`](DocumentClient.md)
+[`ModelInstanceClient`](ModelInstanceClient.md)
 
 #### Inherited from
 

--- a/packages/model-instance-client/src/client.ts
+++ b/packages/model-instance-client/src/client.ts
@@ -35,7 +35,7 @@ export type PostDataParams<T extends UnknownContent = UnknownContent> = Omit<
   controller?: DID
 }
 
-export class DocumentClient extends StreamClient {
+export class ModelInstanceClient extends StreamClient {
   /** Get a DocumentEvent based on its commit ID */
   async getEvent(commitID: CommitID | string): Promise<DocumentEvent> {
     const id =

--- a/packages/model-instance-client/src/index.ts
+++ b/packages/model-instance-client/src/index.ts
@@ -1,5 +1,5 @@
 export {
-  DocumentClient,
+  ModelInstanceClient,
   type PostDataParams,
   type PostDeterministicInitParams,
   type PostSignedInitParams,

--- a/packages/model-instance-client/test/lib.test.ts
+++ b/packages/model-instance-client/test/lib.test.ts
@@ -12,7 +12,7 @@ import { jest } from '@jest/globals'
 import { equals } from 'uint8arrays'
 
 import {
-  DocumentClient,
+  ModelInstanceClient,
   createDataEvent,
   createInitEvent,
   getDeterministicInitEvent,
@@ -136,14 +136,14 @@ describe('createDataEvent()', () => {
   })
 })
 
-describe('DocumentClient', () => {
+describe('ModelInstanceClient', () => {
   describe('getEvent() method', () => {
     test('gets a MID event by commit ID', async () => {
       const streamID = randomStreamID()
       const docEvent = getDeterministicInitEvent(streamID, 'did:key:123')
       const getEventType = jest.fn(() => docEvent)
       const ceramic = { getEventType } as unknown as CeramicClient
-      const client = new DocumentClient({ ceramic, did: authenticatedDID })
+      const client = new ModelInstanceClient({ ceramic, did: authenticatedDID })
 
       const commitID = CommitID.fromStream(streamID)
       const event = await client.getEvent(CommitID.fromStream(streamID))
@@ -159,7 +159,7 @@ describe('DocumentClient', () => {
     test('posts the deterministic init event and returns the MID init CommitID', async () => {
       const postEventType = jest.fn(() => randomCID())
       const ceramic = { postEventType } as unknown as CeramicClient
-      const client = new DocumentClient({ ceramic, did: authenticatedDID })
+      const client = new ModelInstanceClient({ ceramic, did: authenticatedDID })
 
       const id = await client.postDeterministicInit({
         controller: 'did:key:123',
@@ -175,7 +175,7 @@ describe('DocumentClient', () => {
     test('posts the signed init event and returns the MID init CommitID', async () => {
       const postEventType = jest.fn(() => randomCID())
       const ceramic = { postEventType } as unknown as CeramicClient
-      const client = new DocumentClient({ ceramic, did: authenticatedDID })
+      const client = new ModelInstanceClient({ ceramic, did: authenticatedDID })
 
       const id = await client.postSignedInit({
         content: { test: true },
@@ -192,7 +192,7 @@ describe('DocumentClient', () => {
     test('posts the signed data event and returns the CommitID', async () => {
       const postEventType = jest.fn(() => randomCID())
       const ceramic = { postEventType } as unknown as CeramicClient
-      const client = new DocumentClient({ ceramic, did: authenticatedDID })
+      const client = new ModelInstanceClient({ ceramic, did: authenticatedDID })
 
       const initCommitID = await client.postSignedInit({
         content: { test: 0 },

--- a/tests/c1-integration/test/classes.test.ts
+++ b/tests/c1-integration/test/classes.test.ts
@@ -5,7 +5,7 @@ import {
   type ModelState,
   handleInitEvent as handleModel,
 } from '@ceramic-sdk/model-handler'
-import { DocumentClient } from '@ceramic-sdk/model-instance-client'
+import { ModelInstanceClient } from '@ceramic-sdk/model-instance-client'
 import {
   type DocumentState,
   handleEvent as handleDocument,
@@ -80,7 +80,7 @@ describe('stream classes', () => {
       context,
     )
 
-    const docClient = new DocumentClient({
+    const docClient = new ModelInstanceClient({
       ceramic: client,
       did: authenticatedDID,
     })
@@ -169,7 +169,7 @@ describe('stream classes', () => {
       context,
     )
 
-    const docClient = new DocumentClient({
+    const docClient = new ModelInstanceClient({
       ceramic: client,
       did: authenticatedDID,
     })


### PR DESCRIPTION
- Changes from DocumentClient to ModelInstanceClient for consistency