### PR TITLE
Removes log from DocumentState

### DIFF
--- a/packages/model-client/src/index.ts
+++ b/packages/model-client/src/index.ts
@@ -3,6 +3,7 @@ import {
   SignedEvent,
   createSignedInitEvent,
   decodeMultibaseToJSON,
+  decodeMultibaseToStreamID,
   eventToContainer,
 } from '@ceramic-sdk/events'
 import { StreamID } from '@ceramic-sdk/identifiers'
@@ -69,11 +70,21 @@ export class ModelClient extends StreamClient {
     return getModelStreamID(cid)
   }
 
+  /** Retrieve the stringified model stream ID from a stream */
+  async getDocumentModel(streamID: StreamID | string): Promise<string> {
+    const id =
+      typeof streamID === 'string' ? StreamID.fromString(streamID) : streamID
+    const streamState = await this.getStreamState(id)
+    const stream = decodeMultibaseToStreamID(streamState.dimensions.model)
+    return stream.toString()
+  }
+
   /** Retrieve a model's JSON definition */
   async getModelDefinition(
     streamID: StreamID | string,
   ): Promise<ModelDefinition> {
-    const id = typeof streamID === 'string' ? streamID : streamID.toString() // Convert StreamID to string
+    const id =
+      typeof streamID === 'string' ? StreamID.fromString(streamID) : streamID
     const streamState = await this.getStreamState(id)
     const decodedData = decodeMultibaseToJSON(streamState.data)
       .content as ModelDefinition

--- a/packages/model-instance-client/src/client.ts
+++ b/packages/model-instance-client/src/client.ts
@@ -4,7 +4,7 @@ import {
   decodeMultibaseToJSON,
   decodeMultibaseToStreamID,
 } from '@ceramic-sdk/events'
-import { CommitID, type StreamID } from '@ceramic-sdk/identifiers'
+import { CommitID, StreamID } from '@ceramic-sdk/identifiers'
 import {
   DocumentEvent,
   getStreamID,
@@ -120,8 +120,10 @@ export class ModelInstanceClient extends StreamClient {
   }
 
   /** Retrieve and return document state */
-  async getDocumentState(streamID: string): Promise<DocumentState> {
-    const streamState = await this.getStreamState(streamID)
+  async getDocumentState(streamID: StreamID | string): Promise<DocumentState> {
+    const id =
+      typeof streamID === 'string' ? StreamID.fromString(streamID) : streamID
+    const streamState = await this.getStreamState(id)
     return this.streamStateToDocumentState(streamState)
   }
 
@@ -133,7 +135,9 @@ export class ModelInstanceClient extends StreamClient {
     let currentId: CommitID
     // If currentState is not provided, fetch the current state
     if (!params.currentState) {
-      const streamState = await this.getStreamState(params.streamID)
+      const streamState = await this.getStreamState(
+        StreamID.fromString(params.streamID),
+      )
       currentState = this.streamStateToDocumentState(streamState)
       currentId = this.getCurrentID(streamState.event_cid)
     } else {

--- a/packages/model-instance-client/test/lib.test.ts
+++ b/packages/model-instance-client/test/lib.test.ts
@@ -1,6 +1,11 @@
 import { assertSignedEvent, getSignedEventPayload } from '@ceramic-sdk/events'
 import type { CeramicClient } from '@ceramic-sdk/http-client'
-import { CommitID, randomCID, randomStreamID } from '@ceramic-sdk/identifiers'
+import {
+  CommitID,
+  StreamID,
+  randomCID,
+  randomStreamID,
+} from '@ceramic-sdk/identifiers'
 import {
   DataInitEventPayload,
   DocumentDataEventPayload,
@@ -250,7 +255,9 @@ describe('ModelInstanceClient', () => {
       } as unknown as CeramicClient
       const client = new ModelInstanceClient({ ceramic, did: authenticatedDID })
 
-      const documentState = await client.getDocumentState(streamId)
+      const documentState = await client.getDocumentState(
+        StreamID.fromString(streamId),
+      )
       expect(documentState.content).toEqual(docState.content)
       expect(documentState.metadata.model.toString()).toEqual(
         docState.metadata.model,

--- a/packages/model-instance-handler/src/assertions.ts
+++ b/packages/model-instance-handler/src/assertions.ts
@@ -1,6 +1,4 @@
-import type { TimeEvent } from '@ceramic-sdk/events'
 import type {
-  DocumentDataEventPayload,
   DocumentInitEventHeader,
   DocumentMetadata,
   JSONPatchOperation,
@@ -10,7 +8,7 @@ import addFormats from 'ajv-formats'
 import Ajv from 'ajv/dist/2020.js'
 import { equals } from 'uint8arrays'
 
-import type { DocumentState, UnknownContent } from './types.js'
+import type { UnknownContent } from './types.js'
 import { getUniqueFieldsValue } from './utils.js'
 
 const validator = new Ajv({
@@ -145,29 +143,29 @@ export function assertValidUniqueValue(
  * if this check were to fail as part of a StreamtypeHandler's applyCommit function, that would
  * indicate a programming error.
  */
-export function assertEventLinksToState(
-  payload: DocumentDataEventPayload | TimeEvent,
-  state: DocumentState,
-) {
-  if (state.log.length === 0) {
-    throw new Error('Invalid document state: log is empty')
-  }
+// export function assertEventLinksToState(
+//   payload: DocumentDataEventPayload | TimeEvent,
+//   state: DocumentState,
+// ) {
+//   if (state.log.length === 0) {
+//     throw new Error('Invalid document state: log is empty')
+//   }
 
-  const initCID = state.log[0]
+//   const initCID = state.log[0]
 
-  // Older versions of the CAS created time events without an 'id' field, so only check
-  // the event payload 'id' field if it is present.
-  if (payload.id != null && payload.id.toString() !== initCID) {
-    throw new Error(
-      `Invalid init CID in event payload for document, expected ${initCID} but got ${payload.id}`,
-    )
-  }
+//   // Older versions of the CAS created time events without an 'id' field, so only check
+//   // the event payload 'id' field if it is present.
+//   if (payload.id != null && payload.id.toString() !== initCID) {
+//     throw new Error(
+//       `Invalid init CID in event payload for document, expected ${initCID} but got ${payload.id}`,
+//     )
+//   }
 
-  const prev = payload.prev.toString()
-  const expectedPrev = state.log[state.log.length - 1]
-  if (prev !== expectedPrev) {
-    throw new Error(
-      `Commit doesn't properly point to previous event payload in log for document ${initCID}. Expected ${expectedPrev}, found 'prev' ${prev}`,
-    )
-  }
-}
+//   const prev = payload.prev.toString()
+//   const expectedPrev = state.log[state.log.length - 1]
+//   if (prev !== expectedPrev) {
+//     throw new Error(
+//       `Commit doesn't properly point to previous event payload in log for document ${initCID}. Expected ${expectedPrev}, found 'prev' ${prev}`,
+//     )
+//   }
+// }

--- a/packages/model-instance-handler/src/assertions.ts
+++ b/packages/model-instance-handler/src/assertions.ts
@@ -133,39 +133,3 @@ export function assertValidUniqueValue(
     )
   }
 }
-
-/**
- * Asserts that the 'id' and 'prev' properties of the given event properly link to the tip of
- * the given document state.
- *
- * By the time the code gets into a StreamtypeHandler's applyCommit function the link to the state
- * should already have been established by the stream loading and conflict resolution code, so
- * if this check were to fail as part of a StreamtypeHandler's applyCommit function, that would
- * indicate a programming error.
- */
-// export function assertEventLinksToState(
-//   payload: DocumentDataEventPayload | TimeEvent,
-//   state: DocumentState,
-// ) {
-//   if (state.log.length === 0) {
-//     throw new Error('Invalid document state: log is empty')
-//   }
-
-//   const initCID = state.log[0]
-
-//   // Older versions of the CAS created time events without an 'id' field, so only check
-//   // the event payload 'id' field if it is present.
-//   if (payload.id != null && payload.id.toString() !== initCID) {
-//     throw new Error(
-//       `Invalid init CID in event payload for document, expected ${initCID} but got ${payload.id}`,
-//     )
-//   }
-
-//   const prev = payload.prev.toString()
-//   const expectedPrev = state.log[state.log.length - 1]
-//   if (prev !== expectedPrev) {
-//     throw new Error(
-//       `Commit doesn't properly point to previous event payload in log for document ${initCID}. Expected ${expectedPrev}, found 'prev' ${prev}`,
-//     )
-//   }
-// }

--- a/packages/model-instance-handler/src/types.ts
+++ b/packages/model-instance-handler/src/types.ts
@@ -7,7 +7,6 @@ export type UnknownContent = Record<string, unknown>
 export type DocumentState = {
   content: UnknownContent | null
   metadata: DocumentMetadata
-  log: [string, ...Array<string>]
 }
 
 export type Context = {

--- a/packages/model-instance-handler/src/utils.ts
+++ b/packages/model-instance-handler/src/utils.ts
@@ -1,4 +1,3 @@
-import { DocumentDataEventPayload } from '@ceramic-sdk/model-instance-protocol'
 import type { ModelDefinition } from '@ceramic-sdk/model-protocol'
 import { fromString as bytesFromString } from 'uint8arrays'
 
@@ -22,9 +21,7 @@ export function getImmutableFieldsToCheck(
   // Check if the stream is deterministic
   if (['set', 'single'].includes(definition.accountRelation.type)) {
     // Should check immutable fields if there is already a data event present, otherwise it is the first data event that sets the content of the deterministic stream
-    return state.log.some(DocumentDataEventPayload.is)
-      ? definition.immutableFields
-      : []
+    return state.content != null ? definition.immutableFields : []
   }
 
   // Should check immutable fields for all data events on non-deterministic streams

--- a/packages/model-instance-handler/test/assertions.test.ts
+++ b/packages/model-instance-handler/test/assertions.test.ts
@@ -7,7 +7,6 @@ import type {
 import type { ModelDefinitionV2 } from '@ceramic-sdk/model-protocol'
 
 import {
-  assertEventLinksToState,
   assertNoImmutableFieldChange,
   assertValidContent,
   assertValidInitHeader,
@@ -16,46 +15,46 @@ import {
 import type { DocumentState } from '../src/types.js'
 import { encodeUniqueFieldsValue } from '../src/utils.js'
 
-describe('assertEventLinksToState()', () => {
-  test('throws if the state log is empty', () => {
-    const cid = randomCID()
-    expect(() => {
-      assertEventLinksToState(
-        { id: cid } as unknown as DocumentDataEventPayload,
-        { log: [] } as unknown as DocumentState,
-      )
-    }).toThrow('Invalid document state: log is empty')
-  })
+// describe('assertEventLinksToState()', () => {
+//   test('throws if the state log is empty', () => {
+//     const cid = randomCID()
+//     expect(() => {
+//       assertEventLinksToState(
+//         { id: cid } as unknown as DocumentDataEventPayload,
+//         { log: [] } as unknown as DocumentState,
+//       )
+//     }).toThrow('Invalid document state: log is empty')
+//   })
 
-  test('throws if the event id does not match the init event cid', () => {
-    const expectedID = randomCID().toString()
-    const invalidID = randomCID()
-    expect(() => {
-      assertEventLinksToState(
-        { id: invalidID } as unknown as DocumentDataEventPayload,
-        { log: [expectedID] } as unknown as DocumentState,
-      )
-    }).toThrow(
-      `Invalid init CID in event payload for document, expected ${expectedID} but got ${invalidID}`,
-    )
-  })
+//   test('throws if the event id does not match the init event cid', () => {
+//     const expectedID = randomCID().toString()
+//     const invalidID = randomCID()
+//     expect(() => {
+//       assertEventLinksToState(
+//         { id: invalidID } as unknown as DocumentDataEventPayload,
+//         { log: [expectedID] } as unknown as DocumentState,
+//       )
+//     }).toThrow(
+//       `Invalid init CID in event payload for document, expected ${expectedID} but got ${invalidID}`,
+//     )
+//   })
 
-  test('throws if the event prev does not match the previous event cid', () => {
-    const initID = randomCID()
-    const expectedID = randomCID()
-    const invalidID = randomCID()
-    expect(() => {
-      assertEventLinksToState(
-        { id: initID, prev: invalidID } as unknown as DocumentDataEventPayload,
-        {
-          log: [initID.toString(), expectedID.toString()],
-        } as unknown as DocumentState,
-      )
-    }).toThrow(
-      `Commit doesn't properly point to previous event payload in log for document ${initID}. Expected ${expectedID}, found 'prev' ${invalidID}`,
-    )
-  })
-})
+//   test('throws if the event prev does not match the previous event cid', () => {
+//     const initID = randomCID()
+//     const expectedID = randomCID()
+//     const invalidID = randomCID()
+//     expect(() => {
+//       assertEventLinksToState(
+//         { id: initID, prev: invalidID } as unknown as DocumentDataEventPayload,
+//         {
+//           log: [initID.toString(), expectedID.toString()],
+//         } as unknown as DocumentState,
+//       )
+//     }).toThrow(
+//       `Commit doesn't properly point to previous event payload in log for document ${initID}. Expected ${expectedID}, found 'prev' ${invalidID}`,
+//     )
+//   })
+// })
 
 describe('assertNoImmutableFieldChange()', () => {
   test('throws if an immutable field is changed', () => {

--- a/packages/model-instance-handler/test/assertions.test.ts
+++ b/packages/model-instance-handler/test/assertions.test.ts
@@ -15,47 +15,6 @@ import {
 import type { DocumentState } from '../src/types.js'
 import { encodeUniqueFieldsValue } from '../src/utils.js'
 
-// describe('assertEventLinksToState()', () => {
-//   test('throws if the state log is empty', () => {
-//     const cid = randomCID()
-//     expect(() => {
-//       assertEventLinksToState(
-//         { id: cid } as unknown as DocumentDataEventPayload,
-//         { log: [] } as unknown as DocumentState,
-//       )
-//     }).toThrow('Invalid document state: log is empty')
-//   })
-
-//   test('throws if the event id does not match the init event cid', () => {
-//     const expectedID = randomCID().toString()
-//     const invalidID = randomCID()
-//     expect(() => {
-//       assertEventLinksToState(
-//         { id: invalidID } as unknown as DocumentDataEventPayload,
-//         { log: [expectedID] } as unknown as DocumentState,
-//       )
-//     }).toThrow(
-//       `Invalid init CID in event payload for document, expected ${expectedID} but got ${invalidID}`,
-//     )
-//   })
-
-//   test('throws if the event prev does not match the previous event cid', () => {
-//     const initID = randomCID()
-//     const expectedID = randomCID()
-//     const invalidID = randomCID()
-//     expect(() => {
-//       assertEventLinksToState(
-//         { id: initID, prev: invalidID } as unknown as DocumentDataEventPayload,
-//         {
-//           log: [initID.toString(), expectedID.toString()],
-//         } as unknown as DocumentState,
-//       )
-//     }).toThrow(
-//       `Commit doesn't properly point to previous event payload in log for document ${initID}. Expected ${expectedID}, found 'prev' ${invalidID}`,
-//     )
-//   })
-// })
-
 describe('assertNoImmutableFieldChange()', () => {
   test('throws if an immutable field is changed', () => {
     expect(() => {

--- a/packages/stream-client/package.json
+++ b/packages/stream-client/package.json
@@ -32,7 +32,8 @@
     "prepublishOnly": "package-check"
   },
   "dependencies": {
-    "@ceramic-sdk/http-client": "workspace:^"
+    "@ceramic-sdk/http-client": "workspace:^",
+    "@ceramic-sdk/identifiers": "workspace:^"
   },
   "devDependencies": {
     "dids": "^5.0.2"

--- a/packages/stream-client/src/index.ts
+++ b/packages/stream-client/src/index.ts
@@ -1,4 +1,5 @@
 import { type CeramicClient, getCeramicClient } from '@ceramic-sdk/http-client'
+import type { StreamID } from '@ceramic-sdk/identifiers'
 import type { DID } from 'dids'
 
 export type StreamState = {
@@ -40,11 +41,16 @@ export class StreamClient {
    * @param streamId - Multibase encoded stream ID
    * @returns The state of the stream
    */
-  async getStreamState(streamId: string): Promise<StreamState> {
+  async getStreamState(streamId: StreamID | string): Promise<StreamState> {
     const { data, error } = await this.#ceramic.api.GET(
       '/streams/{stream_id}',
       {
-        params: { path: { stream_id: streamId } },
+        params: {
+          path: {
+            stream_id:
+              typeof streamId === 'string' ? streamId : streamId.toString(),
+          },
+        },
       },
     )
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -456,6 +456,9 @@ importers:
       '@ceramic-sdk/http-client':
         specifier: workspace:^
         version: link:../http-client
+      '@ceramic-sdk/identifiers':
+        specifier: workspace:^
+        version: link:../identifiers
     devDependencies:
       dids:
         specifier: ^5.0.2
@@ -622,6 +625,9 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0
     devDependencies:
+      dids:
+        specifier: ^5.0.2
+        version: 5.0.2(typescript@5.6.2)(zod@3.23.8)
       multiformats:
         specifier: ^13.3.0
         version: 13.3.0

--- a/tests/c1-integration/package.json
+++ b/tests/c1-integration/package.json
@@ -40,7 +40,8 @@
     "modern-spawn": "^1.0.0"
   },
   "devDependencies": {
-    "multiformats": "^13.3.0"
+    "multiformats": "^13.3.0",
+    "dids": "^5.0.2"
   },
   "jest": {
     "extensionsToTreatAsEsm": [".ts"],

--- a/tests/c1-integration/test/classes.test.ts
+++ b/tests/c1-integration/test/classes.test.ts
@@ -7,6 +7,7 @@ import {
 } from '@ceramic-sdk/model-handler'
 import { ModelInstanceClient } from '@ceramic-sdk/model-instance-client'
 import {
+  type Context,
   type DocumentState,
   handleEvent as handleDocument,
 } from '@ceramic-sdk/model-instance-handler'
@@ -60,7 +61,7 @@ describe('stream classes', () => {
     const modelsStore: Record<string, ModelState> = {}
     const contextDocumentModel = modelID.baseID.toString()
     let docState: DocumentState
-    const context = {
+    const context: Context = {
       getDocumentModel: async () => contextDocumentModel,
       getDocumentState: async () => docState,
       getModelDefinition: async (id) => {
@@ -90,11 +91,7 @@ describe('stream classes', () => {
       model: modelID,
     })
     const initEvent = await docClient.getEvent(initCommitID)
-    docState = await handleDocument(
-      initCommitID.commit.toString(),
-      initEvent,
-      context,
-    )
+    docState = await handleDocument(initEvent, context)
     expect(docState.content).toBeNull()
 
     const updateCommitID = await docClient.postData({
@@ -102,11 +99,7 @@ describe('stream classes', () => {
       newContent: { test: 'set' },
     })
     const updateEvent = await docClient.getEvent(updateCommitID)
-    docState = await handleDocument(
-      updateCommitID.commit.toString(),
-      updateEvent,
-      context,
-    )
+    docState = await handleDocument(updateEvent, context)
     expect(docState.content).toEqual({ test: 'set' })
 
     const finalCommitID = await docClient.postData({
@@ -114,11 +107,7 @@ describe('stream classes', () => {
       newContent: { test: 'changed' },
     })
     const finalEvent = await docClient.getEvent(finalCommitID)
-    docState = await handleDocument(
-      finalCommitID.commit.toString(),
-      finalEvent,
-      context,
-    )
+    docState = await handleDocument(finalEvent, context)
     expect(docState.content).toEqual({ test: 'changed' })
   })
 
@@ -179,11 +168,7 @@ describe('stream classes', () => {
       model: modelID,
     })
     const initEvent = await docClient.getEvent(initCommitID)
-    docState = await handleDocument(
-      initCommitID.commit.toString(),
-      initEvent,
-      context,
-    )
+    docState = await handleDocument(initEvent, context)
     expect(docState.content).toEqual({ test: 'one' })
 
     const updateCommitID = await docClient.postData({
@@ -191,11 +176,7 @@ describe('stream classes', () => {
       newContent: { test: 'two' },
     })
     const updateEvent = await docClient.getEvent(updateCommitID)
-    docState = await handleDocument(
-      updateCommitID.commit.toString(),
-      updateEvent,
-      context,
-    )
+    docState = await handleDocument(updateEvent, context)
     expect(docState.content).toEqual({ test: 'two' })
 
     const finalCommitID = await docClient.postData({
@@ -203,11 +184,7 @@ describe('stream classes', () => {
       newContent: { test: 'three' },
     })
     const finalEvent = await docClient.getEvent(finalCommitID)
-    docState = await handleDocument(
-      finalCommitID.commit.toString(),
-      finalEvent,
-      context,
-    )
+    docState = await handleDocument(finalEvent, context)
     expect(docState.content).toEqual({ test: 'three' })
   })
 

--- a/tests/c1-integration/test/model-mid-listType.test.ts
+++ b/tests/c1-integration/test/model-mid-listType.test.ts
@@ -1,5 +1,6 @@
 import { CeramicClient } from '@ceramic-sdk/http-client'
-import type { CommitID, StreamID } from '@ceramic-sdk/identifiers'
+import type { CommitID } from '@ceramic-sdk/identifiers'
+import { StreamID } from '@ceramic-sdk/identifiers'
 import { ModelClient } from '@ceramic-sdk/model-client'
 import { ModelInstanceClient } from '@ceramic-sdk/model-instance-client'
 import type { ModelDefinition } from '@ceramic-sdk/model-protocol'
@@ -70,14 +71,14 @@ describe('model integration test for list model and MID', () => {
     // wait 1 seconds
     await new Promise((resolve) => setTimeout(resolve, 1000))
     const currentState = await modelInstanceClient.getDocumentState(
-      documentStream.toString(),
+      new StreamID(3, documentStream.commit.toString()),
     )
     expect(currentState.content).toEqual({ test: 'hello' })
   })
   test('updates document and obtains correct state', async () => {
     // update the document
     const updatedState = await modelInstanceClient.updateDocument({
-      streamID: documentStream.toString(),
+      streamID: new StreamID(3, documentStream.commit.toString()).toString(),
       newContent: { test: 'world' },
       shouldIndex: true,
     })

--- a/tests/c1-integration/test/model-mid-setType.test.ts
+++ b/tests/c1-integration/test/model-mid-setType.test.ts
@@ -1,5 +1,5 @@
 import { CeramicClient } from '@ceramic-sdk/http-client'
-import type { CommitID, StreamID } from '@ceramic-sdk/identifiers'
+import { type CommitID, StreamID } from '@ceramic-sdk/identifiers'
 import { ModelClient } from '@ceramic-sdk/model-client'
 import { ModelInstanceClient } from '@ceramic-sdk/model-instance-client'
 import type { ModelDefinition } from '@ceramic-sdk/model-protocol'
@@ -77,14 +77,14 @@ describe('model integration test for list model and MID', () => {
     // wait 1 seconds
     await new Promise((resolve) => setTimeout(resolve, 1000))
     const currentState = await modelInstanceClient.getDocumentState(
-      documentStream.toString(),
+      new StreamID(3, documentStream.commit.toString()),
     )
     expect(currentState.content).toEqual({ test: 'hello' })
   })
   test('updates document and obtains correct state', async () => {
     // update the document
     const updatedState = await modelInstanceClient.updateDocument({
-      streamID: documentStream.toString(),
+      streamID: new StreamID(3, documentStream.commit.toString()).toString(),
       newContent: { test: 'world' },
       shouldIndex: true,
     })

--- a/tests/c1-integration/test/model-mid-singleType.test.ts
+++ b/tests/c1-integration/test/model-mid-singleType.test.ts
@@ -1,5 +1,5 @@
 import { CeramicClient } from '@ceramic-sdk/http-client'
-import type { CommitID, StreamID } from '@ceramic-sdk/identifiers'
+import { type CommitID, StreamID } from '@ceramic-sdk/identifiers'
 import { ModelClient } from '@ceramic-sdk/model-client'
 import { ModelInstanceClient } from '@ceramic-sdk/model-instance-client'
 import type { ModelDefinition } from '@ceramic-sdk/model-protocol'
@@ -69,14 +69,14 @@ describe('model integration test for list model and MID', () => {
     // wait 1 seconds
     await new Promise((resolve) => setTimeout(resolve, 1000))
     const currentState = await modelInstanceClient.getDocumentState(
-      documentStream.toString(),
+      new StreamID(3, documentStream.commit.toString()),
     )
     expect(currentState.content).toEqual(null)
   })
   test('updates document and obtains correct state', async () => {
     // update the document
     const updatedState = await modelInstanceClient.updateDocument({
-      streamID: documentStream.toString(),
+      streamID: new StreamID(3, documentStream.commit.toString()).toString(),
       newContent: { test: 'hello' },
       shouldIndex: true,
     })

--- a/tests/c1-integration/test/model.test.ts
+++ b/tests/c1-integration/test/model.test.ts
@@ -9,7 +9,6 @@ import {
 } from '@ceramic-sdk/model-protocol'
 import { getAuthenticatedDID } from '@didtools/key-did'
 import CeramicOneContainer, { type EnvironmentOptions } from '../src'
-import type ContainerWrapper from '../src/withContainer'
 
 const authenticatedDID = await getAuthenticatedDID(new Uint8Array(32))
 

--- a/tests/c1-integration/test/stream-client.test.ts
+++ b/tests/c1-integration/test/stream-client.test.ts
@@ -76,8 +76,7 @@ describe('stream client', () => {
 
   test('gets a stream', async () => {
     const client = new StreamClient({ ceramic: ceramicClient })
-    console.log(streamId.toString())
-    const streamState = await client.getStreamState(streamId.toString())
+    const streamState = await client.getStreamState(streamId)
     expect(streamState).toBeDefined()
     expect(streamState.id.toString()).toEqual(streamId.toString())
   }, 10000)


### PR DESCRIPTION
- log: [] was previously part of DocumentState's definition in the model-instance-handler packages and corresponding tests

This PR:

- Removes `log` from DocumentState definition
- Updates impacted methods that previously utilized this field
- Updates tests to remove checks for "links to state" based on log contents
- Adds `getDocumentModel()` method to model-client 