### PR TITLE
Fixing ts-essential dependency placement

### DIFF
--- a/apps/explorer/package.json
+++ b/apps/explorer/package.json
@@ -41,6 +41,7 @@
     "postcss-preset-mantine": "^1.17.0",
     "postcss-simple-vars": "^7.0.1",
     "typescript": "^5.6.2",
-    "vite": "^5.4.8"
+    "vite": "^5.4.8",
+    "ts-essentials": "10.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "turbo": "^2.1.2",
     "typedoc": "^0.26.7",
     "typedoc-plugin-markdown": "^4.2.7",
-    "ts-essentials": "^10.0.2",
     "typescript": "^5.6.2"
   },
   "pnpm": {

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -41,7 +41,8 @@
     "dag-jose": "^5.1.1",
     "multiformats": "^13.3.0",
     "multihashes-sync": "^2.0.0",
-    "uint8arrays": "^5.1.0"
+    "uint8arrays": "^5.1.0",
+    "ts-essentials": "^10.0.2"
   },
   "devDependencies": {
     "@didtools/key-did": "^1.0.0",

--- a/packages/model-client/package.json
+++ b/packages/model-client/package.json
@@ -40,7 +40,8 @@
     "@ceramic-sdk/http-client": "workspace:^",
     "@ceramic-sdk/test-utils": "workspace:^",
     "@didtools/key-did": "^1.0.0",
-    "dids": "^5.0.2"
+    "dids": "^5.0.2",
+    "ts-essentials": "^10.0.2"
   },
   "jest": {
     "extensionsToTreatAsEsm": [".ts"],

--- a/packages/model-handler/package.json
+++ b/packages/model-handler/package.json
@@ -45,7 +45,8 @@
     "@didtools/key-did": "^1.0.0",
     "@types/lodash.ismatch": "^4.4.9",
     "json-schema-typed": "^8.0.1",
-    "multiformats": "^13.3.0"
+    "multiformats": "^13.3.0",
+    "ts-essentials": "^10.0.2"
   },
   "jest": {
     "extensionsToTreatAsEsm": [".ts"],

--- a/packages/model-instance-client/package.json
+++ b/packages/model-instance-client/package.json
@@ -42,7 +42,8 @@
     "@ceramic-sdk/http-client": "workspace:^",
     "@didtools/key-did": "^1.0.0",
     "dids": "^5.0.2",
-    "uint8arrays": "^5.1.0"
+    "uint8arrays": "^5.1.0",
+    "ts-essentials": "^10.0.2"
   },
   "jest": {
     "extensionsToTreatAsEsm": [".ts"],

--- a/packages/model-instance-handler/package.json
+++ b/packages/model-instance-handler/package.json
@@ -39,7 +39,8 @@
     "ajv-formats": "^3.0.1",
     "codeco": "^1.4.3",
     "fast-json-patch": "^3.1.1",
-    "uint8arrays": "^5.1.0"
+    "uint8arrays": "^5.1.0",
+    "ts-essentials": "^10.0.2"
   },
   "devDependencies": {
     "@ceramic-sdk/model-instance-client": "workspace:^",

--- a/packages/model-instance-protocol/package.json
+++ b/packages/model-instance-protocol/package.json
@@ -35,7 +35,8 @@
     "@ceramic-sdk/identifiers": "workspace:^",
     "@didtools/codecs": "^3.0.0",
     "codeco": "^1.4.3",
-    "object-sizeof": "^2.6.4"
+    "object-sizeof": "^2.6.4",
+    "ts-essentials": "^10.0.2"
   },
   "devDependencies": {
     "multiformats": "^13.3.0"

--- a/packages/model-protocol/package.json
+++ b/packages/model-protocol/package.json
@@ -38,7 +38,8 @@
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
     "codeco": "^1.4.3",
-    "json-ptr": "^3.1.1"
+    "json-ptr": "^3.1.1",
+    "ts-essentials": "^10.0.2"
   },
   "devDependencies": {
     "@ceramic-sdk/test-utils": "workspace:^",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,9 +38,6 @@ importers:
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@22.7.0)
-      ts-essentials:
-        specifier: ^10.0.2
-        version: 10.0.2(typescript@5.6.2)
       tsx:
         specifier: ^4.19.1
         version: 4.19.1
@@ -138,6 +135,9 @@ importers:
       postcss-simple-vars:
         specifier: ^7.0.1
         version: 7.0.1(postcss@8.4.47)
+      ts-essentials:
+        specifier: 10.0.2
+        version: 10.0.2(typescript@5.6.2)
       typescript:
         specifier: ^5.6.2
         version: 5.6.2
@@ -174,6 +174,9 @@ importers:
       multihashes-sync:
         specifier: ^2.0.0
         version: 2.0.0
+      ts-essentials:
+        specifier: ^10.0.2
+        version: 10.0.2(typescript@5.6.2)
       uint8arrays:
         specifier: ^5.1.0
         version: 5.1.0
@@ -274,6 +277,9 @@ importers:
       dids:
         specifier: ^5.0.2
         version: 5.0.2(typescript@5.6.2)(zod@3.23.8)
+      ts-essentials:
+        specifier: ^10.0.2
+        version: 10.0.2(typescript@5.6.2)
 
   packages/model-handler:
     dependencies:
@@ -314,6 +320,9 @@ importers:
       multiformats:
         specifier: ^13.3.0
         version: 13.3.0
+      ts-essentials:
+        specifier: ^10.0.2
+        version: 10.0.2(typescript@5.6.2)
 
   packages/model-instance-client:
     dependencies:
@@ -345,6 +354,9 @@ importers:
       dids:
         specifier: ^5.0.2
         version: 5.0.2(typescript@5.6.2)(zod@3.23.8)
+      ts-essentials:
+        specifier: ^10.0.2
+        version: 10.0.2(typescript@5.6.2)
       uint8arrays:
         specifier: ^5.1.0
         version: 5.1.0
@@ -372,6 +384,9 @@ importers:
       fast-json-patch:
         specifier: ^3.1.1
         version: 3.1.1
+      ts-essentials:
+        specifier: ^10.0.2
+        version: 10.0.2(typescript@5.6.2)
       uint8arrays:
         specifier: ^5.1.0
         version: 5.1.0
@@ -409,6 +424,9 @@ importers:
       object-sizeof:
         specifier: ^2.6.4
         version: 2.6.5
+      ts-essentials:
+        specifier: ^10.0.2
+        version: 10.0.2(typescript@5.6.2)
     devDependencies:
       multiformats:
         specifier: ^13.3.0
@@ -440,6 +458,9 @@ importers:
       json-ptr:
         specifier: ^3.1.1
         version: 3.1.1
+      ts-essentials:
+        specifier: ^10.0.2
+        version: 10.0.2(typescript@5.6.2)
     devDependencies:
       '@ceramic-sdk/test-utils':
         specifier: workspace:^


### PR DESCRIPTION
ts-essentials is required as a runtime dependency for the following packages:

- events
- model-instance-protocol
- model-protocol
- model-instance-handler

This change overwrites a previous commit and moves ts-essentials out of global devdependencies and back into their original sub-packages, and changes to runtime dependency for the packages listed above.