### PR TITLE
Chore: patch release 0.2.1

### DIFF
--- a/packages/events/CHANGELOG.md
+++ b/packages/events/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ceramic-sdk/events
 
+## 0.2.1
+
+### Patch Changes
+
+- Fix to ts-essentials dependency to align with runtime behavior
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ceramic-sdk/events",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "3Box Labs",
   "license": "(Apache-2.0 OR MIT)",
   "keywords": ["ceramic", "events"],

--- a/packages/http-client/CHANGELOG.md
+++ b/packages/http-client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @ceramic-sdk/http-client
 
+## 0.2.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @ceramic-sdk/events@0.2.1
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/http-client/package.json
+++ b/packages/http-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ceramic-sdk/http-client",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "3Box Labs",
   "license": "(Apache-2.0 OR MIT)",
   "keywords": ["ceramic", "http", "client"],

--- a/packages/model-client/CHANGELOG.md
+++ b/packages/model-client/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @ceramic-sdk/model-client
 
+## 0.2.1
+
+### Patch Changes
+
+- Fix to ts-essentials dependency to align with runtime behavior
+- Updated dependencies
+  - @ceramic-sdk/events@0.2.1
+  - @ceramic-sdk/model-protocol@0.2.1
+  - @ceramic-sdk/stream-client@0.2.1
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/model-client/package.json
+++ b/packages/model-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ceramic-sdk/model-client",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "3Box Labs",
   "license": "(Apache-2.0 OR MIT)",
   "keywords": ["ceramic", "stream", "model", "client"],

--- a/packages/model-handler/CHANGELOG.md
+++ b/packages/model-handler/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @ceramic-sdk/model-handler
 
+## 0.2.1
+
+### Patch Changes
+
+- Fix to ts-essentials dependency to align with runtime behavior
+- Updated dependencies
+  - @ceramic-sdk/events@0.2.1
+  - @ceramic-sdk/model-protocol@0.2.1
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/model-handler/package.json
+++ b/packages/model-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ceramic-sdk/model-handler",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "3Box Labs",
   "license": "(Apache-2.0 OR MIT)",
   "keywords": ["ceramic", "stream", "model", "handler"],

--- a/packages/model-handler/package.json
+++ b/packages/model-handler/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@ceramic-sdk/model-handler",
   "version": "0.2.0",
-  "private": true,
   "author": "3Box Labs",
   "license": "(Apache-2.0 OR MIT)",
   "keywords": ["ceramic", "stream", "model", "handler"],

--- a/packages/model-instance-client/CHANGELOG.md
+++ b/packages/model-instance-client/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @ceramic-sdk/model-instance-client
 
+## 0.2.1
+
+### Patch Changes
+
+- Fix to ts-essentials dependency to align with runtime behavior
+- Updated dependencies
+  - @ceramic-sdk/events@0.2.1
+  - @ceramic-sdk/model-instance-protocol@0.2.1
+  - @ceramic-sdk/stream-client@0.2.1
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/model-instance-client/package.json
+++ b/packages/model-instance-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ceramic-sdk/model-instance-client",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "3Box Labs",
   "license": "(Apache-2.0 OR MIT)",
   "keywords": ["ceramic", "stream", "model", "document", "client"],

--- a/packages/model-instance-handler/CHANGELOG.md
+++ b/packages/model-instance-handler/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @ceramic-sdk/model-instance-handler
 
+## 0.2.1
+
+### Patch Changes
+
+- Fix to ts-essentials dependency to align with runtime behavior
+- Updated dependencies
+  - @ceramic-sdk/events@0.2.1
+  - @ceramic-sdk/model-instance-protocol@0.2.1
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/model-instance-handler/package.json
+++ b/packages/model-instance-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ceramic-sdk/model-instance-handler",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "3Box Labs",
   "license": "(Apache-2.0 OR MIT)",
   "keywords": ["ceramic", "stream", "model", "document"],

--- a/packages/model-instance-handler/package.json
+++ b/packages/model-instance-handler/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@ceramic-sdk/model-instance-handler",
   "version": "0.2.0",
-  "private": true,
   "author": "3Box Labs",
   "license": "(Apache-2.0 OR MIT)",
   "keywords": ["ceramic", "stream", "model", "document"],

--- a/packages/model-instance-protocol/CHANGELOG.md
+++ b/packages/model-instance-protocol/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @ceramic-sdk/model-instance-protocol
 
+## 0.2.1
+
+### Patch Changes
+
+- Fix to ts-essentials dependency to align with runtime behavior
+- Updated dependencies
+  - @ceramic-sdk/events@0.2.1
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/model-instance-protocol/package.json
+++ b/packages/model-instance-protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ceramic-sdk/model-instance-protocol",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "3Box Labs",
   "license": "(Apache-2.0 OR MIT)",
   "keywords": ["ceramic", "stream", "model", "document"],

--- a/packages/model-protocol/CHANGELOG.md
+++ b/packages/model-protocol/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @ceramic-sdk/model-protocol
 
+## 0.2.1
+
+### Patch Changes
+
+- Fix to ts-essentials dependency to align with runtime behavior
+- Updated dependencies
+  - @ceramic-sdk/events@0.2.1
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/model-protocol/package.json
+++ b/packages/model-protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ceramic-sdk/model-protocol",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "3Box Labs",
   "license": "(Apache-2.0 OR MIT)",
   "keywords": ["ceramic", "stream", "model"],

--- a/packages/stream-client/CHANGELOG.md
+++ b/packages/stream-client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @ceramic-sdk/stream-client
 
+## 0.2.1
+
+### Patch Changes
+
+- @ceramic-sdk/http-client@0.2.1
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/stream-client/package.json
+++ b/packages/stream-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ceramic-sdk/stream-client",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "3Box Labs",
   "license": "(Apache-2.0 OR MIT)",
   "keywords": ["ceramic", "stream", "client"],


### PR DESCRIPTION
- ts-essentials moved to runtime dependencies across several packages
- two packages made public (model-instance-handler and model-protocol)