### PR TITLE
feat: update SDK now that c1 validates streams

### DIFF
--- a/tests/c1-integration/src/index.ts
+++ b/tests/c1-integration/src/index.ts
@@ -110,7 +110,7 @@ export async function waitForEventState(
   event_cid: CID,
 ) {
   await flightClient.preparedQuery(
-    'SELECT "index" FROM event_states_feed WHERE event_cid = $event_cid LIMIT 1',
+    'SELECT event_state_order FROM event_states_feed WHERE event_cid = $event_cid LIMIT 1',
     new Array(['$event_cid', event_cid.toString(base64.encoder)]),
   )
 }

--- a/tests/c1-integration/test/model-mid-setType.test.ts
+++ b/tests/c1-integration/test/model-mid-setType.test.ts
@@ -91,7 +91,7 @@ describe('model integration test for list model and MID', () => {
   test('creates instance and obtains correct state', async () => {
     const documentStream = await modelInstanceClient.createInstance({
       model: modelStream,
-      content: { test: 'hello' },
+      content: null,
       shouldIndex: true,
     })
     // Use the flightsql stream behavior to ensure the events states have been process before querying their states.
@@ -100,12 +100,12 @@ describe('model integration test for list model and MID', () => {
     const currentState = await modelInstanceClient.getDocumentState(
       documentStream.baseID,
     )
-    expect(currentState.content).toEqual({ test: 'hello' })
+    expect(currentState.content).toBeNull()
   })
   test('updates document and obtains correct state', async () => {
     const documentStream = await modelInstanceClient.createInstance({
       model: modelStream,
-      content: { test: 'hello' },
+      content: null,
       shouldIndex: true,
     })
     // Use the flightsql stream behavior to ensure the events states have been process before querying their states.


### PR DESCRIPTION
We needed to fix a few tests that created invalid streams. The set relation stream need to create a init event with empty content and then set the data in an update.

The stream client test needs to use a real model definition.